### PR TITLE
finagle-core: Introduce ServerDispatcher and AnnotatedTransport.

### DIFF
--- a/finagle-core/src/test/scala/com/twitter/finagle/server/StringServer.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/server/StringServer.scala
@@ -2,7 +2,8 @@ package com.twitter.finagle.server
 
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle._
-import com.twitter.finagle.transport.Transport
+import com.twitter.finagle.tracing.{Flags, TraceId, SpanId}
+import com.twitter.finagle.transport.{AnnotatedTransport, Transport}
 import com.twitter.finagle.dispatch.SerialServerDispatcher
 import com.twitter.finagle.netty3.Netty3Listener
 import com.twitter.io.Charsets
@@ -33,8 +34,10 @@ private[finagle] trait StringServer {
     protected type Out = String
 
     protected def newListener() = Netty3Listener(StringServerPipeline, params)
-    protected def newDispatcher(transport: Transport[In, Out], service: Service[String, String]) =
-      new SerialServerDispatcher(transport, service)
+    protected def newDispatcher(transport: Transport[In, Out], service: Service[String, String]) = {
+      val f = (a: Any) => TraceId(None, None, SpanId(71L), None, Flags(Flags.Debug))
+      new SerialServerDispatcher(new AnnotatedTransport(transport, f), service)
+    }
   }
 
   val stringServer = Server()

--- a/finagle-core/src/test/scala/com/twitter/finagle/tracing/DefaultTracingTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/tracing/DefaultTracingTest.scala
@@ -1,14 +1,14 @@
 package com.twitter.finagle.tracing
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.Stack
 import com.twitter.finagle._
 import com.twitter.finagle.builder.{ClientBuilder, ServerBuilder}
 import com.twitter.finagle.client._
 import com.twitter.finagle.dispatch._
 import com.twitter.finagle.netty3._
 import com.twitter.finagle.server._
-import com.twitter.finagle.transport.Transport
+import com.twitter.finagle.Stack
+import com.twitter.finagle.transport.{AnnotatedTransport, Transport}
 import com.twitter.finagle.{param => fparam}
 import com.twitter.io.Charsets
 import com.twitter.util._
@@ -82,10 +82,15 @@ class DefaultTracingTest extends FunSuite with StringClient with StringServer {
 
   test("core events are traced in the DefaultClient/DefaultServer") {
     testCoreTraces { (serverTracer, clientTracer) =>
+      val f = (t: Transport[String, String], s: Service[String, String]) => {
+        val g = (a: Any) => TraceId(None, None, SpanId(71L), None, Flags(Flags.Debug))
+        val trans = new AnnotatedTransport(t, g)
+        new SerialServerDispatcher(trans, s)
+      }
       val server = DefaultServer[String, String, String, String](
         name = "theServer",
         listener = Netty3Listener("theServer", StringServerPipeline),
-        serviceTransport = new SerialServerDispatcher(_, _),
+        serviceTransport = f,
         tracer = serverTracer)
 
       val client = DefaultClient[String, String](

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Codec.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Codec.scala
@@ -217,7 +217,8 @@ case class Http(
 
       override def newServerDispatcher(
         transport: Transport[Any, Any],
-        service: Service[Request, Response]
+        service: Service[Request, Response],
+        f: (Any) => TraceId = TraceInfo.TraceIdFromRequest
       ): Closable =
         new HttpServerDispatcher(new HttpTransport(transport), service)
 
@@ -277,6 +278,12 @@ object HttpTracing {
 
 private object TraceInfo {
   import HttpTracing._
+
+  // This should actually work - needs a refactor from a function extracted 
+  // from letTraceIdFromRequestHeaders
+  val TraceIdFromRequest: (Any) => TraceId = (a: Any) => a match {
+    case _ => Trace.id
+  }
 
   def letTraceIdFromRequestHeaders[R](request: Request)(f: => R): R = {
     val id = if (Header.Required.forall { request.headers.contains(_) }) {

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/StreamingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/StreamingTest.scala
@@ -4,16 +4,17 @@ import com.twitter.conversions.time._
 import com.twitter.finagle._
 import com.twitter.finagle.builder.{ClientBuilder, ServerBuilder}
 import com.twitter.finagle.dispatch.GenSerialClientDispatcher
-import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.tracing.TraceId
+import com.twitter.finagle.transport.Transport
 import com.twitter.io.{Buf, Reader, Writer}
 import com.twitter.util.{Await, Closable, Future, Promise}
 import java.net.{InetSocketAddress, SocketAddress}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import org.jboss.netty.channel.Channel
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually
+import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
@@ -353,7 +354,8 @@ object StreamingTest {
           codec.newClientDispatcher(cmod(transport), params)
         override def newServerDispatcher(
           transport: Transport[Any, Any],
-          service: Service[Request, Response]
+          service: Service[Request, Response],
+          f: (Any) => TraceId = TraceInfo.TraceIdFromRequest
         ) = codec.newServerDispatcher(smod(transport), service)
       }
 


### PR DESCRIPTION
Problem:

Clients annotate WireSend and WireRecv at the bottom of the finagle
stack. There is no parallel for a Server. In addition, we would like
to have a simple type for wrapping Transports to be Annotated.

Solution:

Introduce the ServerDispatcher type, which has two methods dispatch
and handle. Introduce the AnnotatedTransporter type as well,
which can wraps any Transporter so that a WireRecv can be
emitted upon receipt and a WireSend upon a successful write.
